### PR TITLE
Fix validateCNP

### DIFF
--- a/src/Cnp.php
+++ b/src/Cnp.php
@@ -20,6 +20,7 @@ use DateTime;
  *      6 = Female, born between 2000 - 2099
  *      7 = Male resident (century does not apply)
  *      8 = Female resident (century does not apply)
+ *      9 = Foreign people (century does not apply)
  *
  * |YY| - year of birth - 00 - 99
  * |MM| - birth month - 01 - 12
@@ -158,9 +159,8 @@ class Cnp
             $this->setYear();
             $this->month = $this->cnpArray[3] . $this->cnpArray[4];
             $this->day = $this->cnpArray[5] . $this->cnpArray[6];
-            $this->countyCode = $this->cnpArray[7] . $this->cnpArray[8];
-
-            if ($this->checkDate() && $this->checkCounty()) {
+            
+            if ($this->checkDate()) {
                 $this->isValid = $this->cnpArray[12] === $this->calculateHash();
             }
         }
@@ -196,7 +196,7 @@ class Cnp
         } elseif (in_array($this->cnpArray[0], [5, 6])) {
             # romanian citizen born between 2000.01.01 and 2099.12.31
             $this->year = $year + 2000;
-        } elseif (in_array($this->cnpArray[0], [7, 8])) {
+        } elseif (in_array($this->cnpArray[0], [7, 8, 9])) {
             # residents && people with foreign citizenship
             $this->year = $year + 2000;
             if ($this->year > (int)date('Y') - 14) {

--- a/src/Cnp.php
+++ b/src/Cnp.php
@@ -159,7 +159,7 @@ class Cnp
             $this->setYear();
             $this->month = $this->cnpArray[3] . $this->cnpArray[4];
             $this->day = $this->cnpArray[5] . $this->cnpArray[6];
-            
+
             if ($this->checkDate()) {
                 $this->isValid = $this->cnpArray[12] === $this->calculateHash();
             }
@@ -292,7 +292,7 @@ class Cnp
      */
     public function getBirthCountyFromCNP(string $invalidReturn = ''): string
     {
-        return $this->isValid ? self::COUNTY_CODE[$this->countyCode] : $invalidReturn;
+        return $this->isValid && array_key_exists($this->countyCode, self::COUNTY_CODE) ? self::COUNTY_CODE[$this->countyCode] : $invalidReturn;
     }
 
     /**


### PR DESCRIPTION
- din functia validateCNP am eliminat checkCounty deoarece sunt si CNP-uri ce nu se incadreaza in judetele de resedinta specificate, vezi discutiile de aici https://ro.wikipedia.org/wiki/Discu%C8%9Bie:Cod_numeric_personal_(Rom%C3%A2nia) , chiar acum si eu am un caz de cnp ce la JJ am 80.

Verificarea hash-ului este mai mult decat ok pentru a mai pune si alte verificari suplimentare.

- am adaugat si S   9 - pentru persoanele străine